### PR TITLE
settings: added default settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.pyc
 conf/local_settings.json
+*.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
+.DS_Store
 *.pyc
-settings.json
 conf/local_settings.json

--- a/conf/__init__.py
+++ b/conf/__init__.py
@@ -1,32 +1,29 @@
-import logging
 import os
 import json
 
-
-SETTINGS = {}
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-
-PATHS_TO_CONF = [
-    os.path.join(BASE_DIR, 'conf', 'local_settings.json'),
-    os.path.join(BASE_DIR, 'conf', 'settings.json')
+settings_directory = os.path.dirname(os.path.realpath(__file__))
+possible_paths = [
+    os.path.join(settings_directory, 'setting.json'),
+    os.path.join(settings_directory, 'default.json')
 ]
 
+config = None
 
-# for each possible path, try to open the file
-# if you can open the file, make it your settings file
-for path in PATHS_TO_CONF:
-    filename = path
-    try:
-        file_content = open(filename, 'r')
-    except IOError:
-        logging.error('File could not be found: {}'.format(filename))
-    try:
-        SETTINGS = json.loads(file_content.read())
-    except ValueError:
-        logging.error('No JSON object could be decoded.')
-    if SETTINGS:
+for file_path in possible_paths:
+    if not os.path.isfile(file_path):
+        continue
+
+    with open(file_path, 'r') as f:
+        file_data = f.read()
+        config = json.loads(file_data)
         break
 
+if not config:
+    raise SystemError('Invalid or missing config file')
+
+is_empty = lambda s: None if s == '' else s
+config = {k: is_empty(config[k]) for k in config}
+
+
 def get(key):
-    return SETTINGS.get(key, None)
+    return config[key]

--- a/conf/default.json
+++ b/conf/default.json
@@ -1,5 +1,5 @@
 {
-    "DATABASE_URL": "sqlite:///../pantry_finder.sqlite",
+    "DATABASE_URL": "sqlite:///pantry_finder.sqlite",
     "DEBUG": true,
     "GOOGLE_GEOCODING_API_KEY": "",
     "SECRET_KEY": "pantry_finder_default_o1c@g&o9bfd%!$ak8!b-l=!=db33tt2io0i_+)e5(2hla88pfv_unsafe"

--- a/conf/default.json
+++ b/conf/default.json
@@ -1,0 +1,6 @@
+{
+    "DATABASE_URL": "sqlite:///../pantry_finder.sqlite",
+    "DEBUG": true,
+    "GOOGLE_GEOCODING_API_KEY": "",
+    "SECRET_KEY": "pantry_finder_default_o1c@g&o9bfd%!$ak8!b-l=!=db33tt2io0i_+)e5(2hla88pfv_unsafe"
+}


### PR DESCRIPTION
This PR rewrites the `conf/__init__.py` file and adds defaut settings in `default.json`. 

The way conf.get works now, is tries to load settings from each location in the `possible_paths` list. If none are present, it falls back to the default. 

The default settings places as sqlite db at the root of the project.

@fizal619 @Junmr4  